### PR TITLE
Implement the Mpris plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ include src/libj4status/libj4status.mk
 include src/libj4status-plugin/libj4status-plugin.mk
 include src/output/flat/flat.mk
 include src/output/debug/debug.mk
+
 if ENABLE_I3BAR_INPUT_OUTPUT
 include src/input-output/i3bar/i3bar.mk
 endif
@@ -62,6 +63,9 @@ include src/input/systemd/systemd.mk
 endif
 if ENABLE_I3FOCUS_INPUT
 include src/input/i3focus/i3focus.mk
+endif
+if ENABLE_MPRIS_INPUT
+include src/input/mpris/mpris.mk
 endif
 include man/man.mk
 

--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,7 @@ if test x$have_gio_unix = xyes; then
     gio_unix="gio-unix-2.0"
 fi
 PKG_CHECK_MODULES(GIO, [gio-2.0 >= $gio_min_version $gio_unix])
+AC_SUBST(GDBUS_CODEGEN, `pkg-config --variable=gdbus_codegen gio-2.0`)
 
 PKG_CHECK_MODULES(GMODULE, [gmodule-2.0 >= $gmodule_min_version])
 
@@ -159,6 +160,8 @@ if test x$enable_i3focus_input = xyes; then
 fi
 AM_CONDITIONAL(ENABLE_I3FOCUS_INPUT, test x$enable_i3focus_input = xyes)
 
+AC_ARG_ENABLE(mpris-input, AS_HELP_STRING([--disable-mpris-input], [Disable mpris support]), [], enable_mpris_input=yes)
+AM_CONDITIONAL(ENABLE_MPRIS_INPUT, test x$enable_mpris_input = xyes)
 
 #
 # Tests
@@ -203,6 +206,7 @@ AC_MSG_RESULT([
         systemd: $enable_systemd_input
         i3focus: $enable_i3focus_input
         i3bar: $enable_i3bar_input_output
+        Mpris: $enable_mpris_input
 
 dnl     Tests: $enable_tests
     Debug mode: $enable_debug

--- a/man/j4status-mpris.conf.xml
+++ b/man/j4status-mpris.conf.xml
@@ -1,0 +1,121 @@
+<?xml version='1.0' ?>
+<!DOCTYPE config SYSTEM "config.dtd">
+
+<!--
+  j4status - Status line generator
+
+  Copyright © 2012-2013 Quentin "Sardem FF7" Glidic
+
+  Mpris plugin by Tony Crisci <tony@dubstepdish.com>
+
+  This file is part of j4status.
+
+  j4status is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  j4status is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with j4status. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<refentry id="j4status-mpris.conf">
+    <refentryinfo>
+        <title>&PACKAGE_NAME; Manual</title>
+        <productname>&PACKAGE_NAME;</productname>
+        <productnumber>&PACKAGE_VERSION;</productnumber>
+
+        <authorgroup>
+            <author>
+                <contrib>Developer</contrib>
+                <firstname>Tony</firstname>
+                <surname>Crisci</surname>
+                <email>tony@dubstepdish.com</email>
+            </author>
+        </authorgroup>
+    </refentryinfo>
+
+    <refmeta>
+        <refentrytitle>j4status-mpris.conf</refentrytitle>
+        <manvolnum>5</manvolnum>
+    </refmeta>
+
+    <refnamediv>
+        <refname>j4status-mpris.conf</refname>
+        <refpurpose>j4status Mpris plugin configuration</refpurpose>
+    </refnamediv>
+
+    <refsynopsisdiv>
+        <para>
+            The Mpris plugin displays the artist and title from whatever you have playing in your media player in the status line.
+        </para>
+        <para>
+            The Mpris plugin uses the main j4status configuration file (see <citerefentry><refentrytitle>j4status.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>).
+        </para>
+    </refsynopsisdiv>
+
+    <refsect1 id="description">
+        <title>Description</title>
+
+        <para>
+            It controls the Mpris plugin behavior.
+        </para>
+    </refsect1>
+
+    <refsect1 id="sections">
+        <title>Sections</title>
+
+        <refsect2 id="section-mpris">
+            <title>Section <varname>[Mpris]</varname></title>
+
+            <variablelist>
+                <varlistentry>
+                    <term>
+                        <varname>Player=</varname>
+                        (The <type>name of a media player</type>, defaults to <literal>vlc</literal>)
+                    </term>
+                    <listitem>
+                        <para>The name of a media player that implements the Mpris D-Bus Interface Specification, such as vlc, spotify, audacious, bmp, or xmms2</para>
+                        <para>The Mpris plugin will query metadata from the bus name of org.mpris.MediaPlayer2.[Player]</para>
+                    </listitem>
+                </varlistentry>
+            </variablelist>
+
+        </refsect2>
+    </refsect1>
+
+    <refsect1>
+        <title>Examples</title>
+
+        <example>
+            <title>Displaying the current track you are listening to in Spotify</title>
+
+            <programlisting>
+[Mpris]
+Player=spotify
+            </programlisting>
+            <para>
+                Displays the track metadata in the format “ARTIST - TITLE”.
+            </para>
+            <para>
+                Here is the expected output :
+            </para>
+            <screen>
+One Direction - What Makes You Beautiful
+            </screen>
+        </example>
+
+    </refsect1>
+
+    <refsect1 id="see-also">
+        <title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>j4status.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+        </para>
+    </refsect1>
+</refentry>

--- a/src/input/mpris/mpris-interface.xml
+++ b/src/input/mpris/mpris-interface.xml
@@ -1,0 +1,81 @@
+<node>
+  <interface name="org.mpris.MediaPlayer2">
+    <method name="Raise"/>
+    <method name="Quit"/>
+    <property access="read" type="b" name="CanQuit"/>
+    <property access="read" type="b" name="CanRaise"/>
+    <property access="read" type="b" name="HasTrackList"/>
+    <property access="read" type="s" name="Identity"/>
+    <property access="read" type="s" name="DesktopEntry"/>
+    <property access="read" type="as" name="SupportedUriSchemes"/>
+    <property access="read" type="as" name="SupportedMimeTypes"/>
+  </interface>
+  <interface name="org.mpris.MediaPlayer2.Player">
+    <method name="Next"/>
+    <method name="Previous"/>
+    <method name="Pause"/>
+    <method name="PlayPause"/>
+    <method name="Stop"/>
+    <method name="Play"/>
+    <method name="Seek">
+      <arg direction="in" type="x" name="Offset"/>
+    </method>
+    <method name="SetPosition">
+      <arg direction="in" type="o" name="TrackId"/>
+      <arg direction="in" type="x" name="Position"/>
+    </method>
+    <method name="OpenUri">
+      <arg direction="in" type="s"/>
+    </method>
+    <!-- Signals -->
+    <signal name="Seeked">
+      <arg type="x" name="Position"/>
+    </signal>
+    <!-- Properties -->
+    <property access="read" type="s" name="PlaybackStatus"/>
+    <property access="readwrite" type="s" name="LoopStatus"/>
+    <property access="readwrite" type="d" name="Rate"/>
+    <property access="readwrite" type="b" name="Shuffle"/>
+    <property access="read" type="a{sv}" name="Metadata">
+      <annotation value="QVariantMap" name="com.trolltech.QtDBus.QtTypeName"/>
+    </property>
+    <property access="readwrite" type="d" name="Volume"/>
+    <property access="read" type="x" name="Position"/>
+    <property access="read" type="d" name="MinimumRate"/>
+    <property access="read" type="d" name="MaximumRate"/>
+    <property access="read" type="b" name="CanGoNext"/>
+    <property access="read" type="b" name="CanGoPrevious"/>
+    <property access="read" type="b" name="CanPlay"/>
+    <property access="read" type="b" name="CanPause"/>
+    <property access="read" type="b" name="CanSeek"/>
+    <property access="read" type="b" name="CanControl"/>
+  </interface>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="property_name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="property_name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="in"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="values" type="a{sv}" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping"/>
+    <method name="GetMachineId">
+      <arg name="machine_uuid" type="s" direction="out"/>
+    </method>
+  </interface>
+</node>

--- a/src/input/mpris/mpris.c
+++ b/src/input/mpris/mpris.c
@@ -1,0 +1,166 @@
+/*
+ * j4status - Status line generator
+ *
+ * Copyright © 2012-2013 Quentin "Sardem FF7" Glidic
+ *
+ * Mpris plugin by Tony Crisci <tony@dubstepdish.com>
+ *
+ * MPRIS D-Bus Interface Specification:
+ * http://specifications.freedesktop.org/mpris-spec/latest/index.html
+ *
+ * This file is part of j4status.
+ *
+ * j4status is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * j4status is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with j4status. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <glib-object.h>
+
+#include <j4status-plugin-input.h>
+#include <libj4status-config.h>
+
+#include "mpris-generated.h"
+
+static const gchar *MPRIS_DEFAULT_PLAYER = "vlc";
+
+struct _J4statusPluginContext {
+    OrgMprisMediaPlayer2Player *proxy;
+    J4statusSection *section;
+};
+
+static gchar *
+_j4status_mpris_build_status_text(GVariant *metadata)
+{
+    /* MPRIS v2 metadata guidelines:
+     * http://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata */
+    gchar *status_text;
+    gchar *title = NULL;
+    GVariant *artist_list = NULL;
+    gchar **artist_strv = NULL;
+    gchar *artist = NULL;
+
+    /* return empty string unless the player is active */
+    if ( metadata == NULL || !g_variant_check_format_string(metadata, "a{sv}", FALSE) )
+        return g_strdup("");
+
+    g_variant_lookup(metadata, "xesam:title", "s", &title);
+    artist_list = g_variant_lookup_value(metadata, "xesam:artist", G_VARIANT_TYPE_ARRAY);
+
+    if ( artist_list != NULL)
+    {
+        artist_strv = g_variant_dup_strv(artist_list, NULL);
+        artist = g_strjoinv(", ", artist_strv);
+    }
+
+    status_text = ( artist == NULL
+                  ? g_strdup(title)
+                  : g_strjoin(" - ", artist, title, NULL) );
+
+    if ( artist_list != NULL )
+        g_variant_unref(artist_list);
+    g_free(title);
+    g_free(artist);
+    g_strfreev(artist_strv);
+
+    return status_text;
+}
+
+static void
+_j4status_properties_changed_callback(GDBusProxy *_proxy, GVariant *changed_properties, const gchar *const *invalidated_properties, gpointer user_data)
+{
+    OrgMprisMediaPlayer2Player *proxy;
+    GVariant *metadata;
+    gchar *status_text;
+
+    J4statusSection *section = user_data;
+
+    proxy = ORG_MPRIS_MEDIA_PLAYER2_PLAYER(_proxy);
+    metadata = org_mpris_media_player2_player_get_metadata(proxy);
+
+    status_text = _j4status_mpris_build_status_text(metadata);
+
+    j4status_section_set_value(section, status_text);
+}
+
+static void _j4status_mpris_uninit(J4statusPluginContext *context);
+
+static J4statusPluginContext *
+_j4status_mpris_init(J4statusCoreInterface *core)
+{
+    GError *error = NULL;
+    GKeyFile *key_file;
+    OrgMprisMediaPlayer2Player *proxy;
+    gchar *player_name;
+    gchar *bus_name;
+
+    key_file = libj4status_config_get_key_file("Mpris");
+
+    player_name = ( key_file == NULL || !g_key_file_has_key(key_file, "Mpris", "Player", NULL)
+                  ? g_strdup(MPRIS_DEFAULT_PLAYER)
+                  : g_key_file_get_string(key_file, "Mpris", "Player", NULL) );
+
+    bus_name = g_strjoin(".", "org.mpris.MediaPlayer2", player_name, NULL);
+
+    proxy = org_mpris_media_player2_player_proxy_new_for_bus_sync(
+            G_BUS_TYPE_SESSION,
+            G_DBUS_PROXY_FLAGS_NONE,
+            bus_name,
+            "/org/mpris/MediaPlayer2",
+            NULL,
+            &error);
+
+    g_free(bus_name);
+    g_free(player_name);
+
+    if ( proxy == NULL )
+    {
+        g_warning("Couldn't establish proxy connection to player: %s", error->message);
+        g_clear_error(&error);
+        return NULL;
+    }
+
+    J4statusPluginContext *context;
+
+    context = g_new0(J4statusPluginContext, 1);
+    context->proxy = proxy;
+
+    context->section = j4status_section_new(core);
+    j4status_section_set_name(context->section, "mpris");
+    if ( ! j4status_section_insert(context->section) )
+    {
+        _j4status_mpris_uninit(context);
+        return NULL;
+    }
+
+    g_signal_connect(context->proxy, "g-properties-changed", G_CALLBACK(_j4status_properties_changed_callback), context->section);
+
+    return context;
+}
+
+static void
+_j4status_mpris_uninit(J4statusPluginContext *context)
+{
+    j4status_section_free(context->section);
+
+    g_object_unref(context->proxy);
+
+    g_free(context);
+}
+
+void
+j4status_input_plugin(J4statusInputPluginInterface *interface)
+{
+    libj4status_input_plugin_interface_add_init_callback(interface, _j4status_mpris_init);
+    libj4status_input_plugin_interface_add_uninit_callback(interface, _j4status_mpris_uninit);
+}

--- a/src/input/mpris/mpris.mk
+++ b/src/input/mpris/mpris.mk
@@ -1,0 +1,43 @@
+src/input/mpris/mpris-generated.c:
+	$(GDBUS_CODEGEN) --generate-c-code src/input/mpris/mpris-generated src/input/mpris/mpris-interface.xml
+
+CLEANFILES+= \
+	src/input/mpris/mpris-generated.c \
+	src/input/mpris/mpris-generated.h \
+	$(null)
+
+plugins_LTLIBRARIES += \
+	mpris.la \
+	$(null)
+
+# sources are generated with:
+# gdbus-codegen --generate-c-code src/input/mpris/mpris-generated src/input/mpris/mpris-interface.xml
+mpris_la_SOURCES = \
+	src/input/mpris/mpris-generated.c \
+	src/input/mpris/mpris.c \
+	src/input/mpris/mpris-generated.h \
+	$(null)
+
+mpris_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(GIO_CFLAGS) \
+	$(GOBJECT_CFLAGS) \
+	$(GLIB_CFLAGS) \
+	$(null)
+
+mpris_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	-module -avoid-version -export-symbols-regex j4status_input \
+	$(null)
+
+mpris_la_LIBADD = \
+	libj4status-plugin.la \
+	libj4status.la \
+	$(GIO_LIBS) \
+	$(GOBJECT_LIBS) \
+	$(GLIB_LIBS) \
+	$(null)
+
+man5_MANS += \
+	man/j4status-mpris.conf.5 \
+	$(null)


### PR DESCRIPTION
The Mpris plugin is for displaying metadata from media players that
implement the MPRIS D-Bus Interface Specification version 2.2.

The latest version of the specification can be found here:
http://specifications.freedesktop.org/mpris-spec/latest/index.html

When configured for a given player, (default vlc), the plugin should
display metadata in the statusline in the format "ARTIST - TITLE" for
the media player with the bus name `org.mpris.MediaPlayer2.[player]`.
