### PR TITLE
i3focus bugfix: update section when con is focused

### DIFF
--- a/src/input/i3focus/i3focus.c
+++ b/src/input/i3focus/i3focus.c
@@ -24,11 +24,12 @@ static void
 _j4status_i3focus_window_callback(GObject *object, i3ipcWindowEvent *event, gpointer user_data)
 {
     J4statusSection *section = user_data;
-    if ( g_strcmp0(event->change, "focus") != 0 )
-        return;
     gchar *name;
-    g_object_get(G_OBJECT(event->container), "name", &name, NULL);
-    j4status_section_set_value(section, name);
+    gboolean focused;
+    g_object_get(G_OBJECT(event->container), "name", &name, "focused", &focused, NULL);
+
+    if (focused)
+        j4status_section_set_value(section, name);
 }
 
 static void _j4status_i3focus_uninit(J4statusPluginContext *context);


### PR DESCRIPTION
Responding only to the "focus" event ignores the new events that are
emitted on title changes.

Title change events are useful for cases such as knowing the title of
the tab you are on in Firefox, or knowing whether or not your vim
buffer has changes which is especially important when titlebars are
disabled.
