### PR TITLE
j4status: always call setlocale()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,8 +15,7 @@ AC_ARG_VAR([XSLTPROC], [The xsltproc executable])
 AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
-AC_CHECK_HEADER([locale.h],[AC_DEFINE([HAVE_LOCALE_H],
-                                      [1], [Found locale.h header])])
+AC_CHECK_HEADERS([locale.h])
 AC_CHECK_FUNCS([setlocale])
 
 AC_PROG_SED

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,10 @@ AC_ARG_VAR([XSLTPROC], [The xsltproc executable])
 AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
+AC_CHECK_HEADER([locale.h],[AC_DEFINE([HAVE_LOCALE_H],
+                                      [1], [Found locale.h header])])
+AC_CHECK_FUNCS([setlocale])
+
 AC_PROG_SED
 AC_DISABLE_STATIC
 LT_INIT

--- a/main/src/j4status.c
+++ b/main/src/j4status.c
@@ -31,6 +31,10 @@
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
 
+#ifdef HAVE_LOCALE_H
+#include <locale.h>
+#endif  /* HAVE_LOCALE_H */
+
 #include <glib.h>
 #include <glib-object.h>
 #include <glib/gstdio.h>
@@ -293,8 +297,11 @@ main(int argc, char *argv[])
     g_setenv("G_MESSAGES_DEBUG", "all", FALSE);
 #endif /* ! DEBUG */
 
-#if ENABLE_NLS
+#ifdef HAVE_SETLOCALE
     setlocale(LC_ALL, "");
+#endif
+
+#if ENABLE_NLS
     bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
 #endif /* ENABLE_NLS */


### PR DESCRIPTION
`setlocale()` needs to be called always regardless of NLS support,
otherwise glib charset detection will not work properly and UTF-8
encoded format fields will not be correctly handled.

Effectively the patch allows setting of time format to:
```
[Time]
Zones=Europe/Warsaw;
Label=test label
Format=  %a %d %b %Y - %H:%M
```