### PR TITLE
sensors: allow crit hysteresis temp to be used instead of max temp

### DIFF
--- a/input/sensors/src/sensors.c
+++ b/input/sensors/src/sensors.c
@@ -265,8 +265,6 @@ _j4status_sensors_add_feature_temp(J4statusPluginContext *context, const sensors
     sensor_feature->subfeatures.input = input;
     sensor_feature->subfeatures.max = sensors_get_subfeature(chip, feature, SENSORS_SUBFEATURE_TEMP_MAX);
     sensor_feature->subfeatures.crit = sensors_get_subfeature(chip, feature, SENSORS_SUBFEATURE_TEMP_CRIT);
-    if ( ( sensor_feature->subfeatures.max == NULL ) && ( sensor_feature->subfeatures.crit != NULL ) )
-        sensor_feature->subfeatures.max = sensors_get_subfeature(chip, feature, SENSORS_SUBFEATURE_TEMP_CRIT_HYST);
     sensor_feature->values.current = -1;
     sensor_feature->values.high = -1;
     sensor_feature->values.crit = -1;

--- a/input/sensors/src/sensors.c
+++ b/input/sensors/src/sensors.c
@@ -265,6 +265,8 @@ _j4status_sensors_add_feature_temp(J4statusPluginContext *context, const sensors
     sensor_feature->subfeatures.input = input;
     sensor_feature->subfeatures.max = sensors_get_subfeature(chip, feature, SENSORS_SUBFEATURE_TEMP_MAX);
     sensor_feature->subfeatures.crit = sensors_get_subfeature(chip, feature, SENSORS_SUBFEATURE_TEMP_CRIT);
+    if ( ( sensor_feature->subfeatures.max == NULL ) && ( sensor_feature->subfeatures.crit != NULL ) )
+        sensor_feature->subfeatures.max = sensors_get_subfeature(chip, feature, SENSORS_SUBFEATURE_TEMP_CRIT_HYST);
     sensor_feature->values.current = -1;
     sensor_feature->values.high = -1;
     sensor_feature->values.crit = -1;


### PR DESCRIPTION
Hello again.  I'd like to propose a tiny hack.  My GPU temperature sensor has no defined 'high' temperature, but does have a 'crit hysteresis' temperature, so I patched my build of sensors plugin to treat it like 'high', displaying the readings in red.  It makes sense as it's also a significant boundary (although mostly only when the GPU cools down after overheating).  Do you think it's enough of a good idea to merge it?