### PR TITLE
upower: Add config keys to control threshold at which state changes

### DIFF
--- a/input/upower/man/j4status-upower.conf.xml
+++ b/input/upower/man/j4status-upower.conf.xml
@@ -121,6 +121,26 @@
                         </para>
                     </listitem>
                 </varlistentry>
+
+                <varlistentry>
+                    <term>
+                        <varname>BadThreshold=</varname>
+                        (<type>integer</type>, defaults to <literal>15</literal>)
+                    </term>
+                    <listitem>
+                        <para>Percentage below which battery level is red</para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>
+                        <varname>UrgentThreshold=</varname>
+                        (<type>integer</type>, defaults to <literal>5</literal>)
+                    </term>
+                    <listitem>
+                        <para>Percentage below which battery level is very red</para>
+                    </listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
     </refsect1>

--- a/input/upower/man/j4status-upower.conf.xml
+++ b/input/upower/man/j4status-upower.conf.xml
@@ -124,6 +124,16 @@
 
                 <varlistentry>
                     <term>
+                        <varname>WarningThreshold=</varname>
+                        (<type>integer</type>, defaults to <literal>25</literal>)
+                    </term>
+                    <listitem>
+                        <para>Percentage below which battery level is yellow</para>
+                    </listitem>
+                </varlistentry>
+
+                <varlistentry>
+                    <term>
                         <varname>BadThreshold=</varname>
                         (<type>integer</type>, defaults to <literal>15</literal>)
                     </term>


### PR DESCRIPTION
Two commits: the first adds config keys to manage existing changes of state in upower; the second is more subjective (which is why it's a separate commit), as I wanted the option of the battery level to not be yellow whenever it isn't plugged in, so I added another change of state, from `no state' to average, and a key to control it.
